### PR TITLE
Add mover warping to level.

### DIFF
--- a/src/main/java/website/frontrow/Launcher.java
+++ b/src/main/java/website/frontrow/Launcher.java
@@ -49,7 +49,7 @@ public class Launcher implements Logable
         // Initialize the Logger Class, so that it can Log actions taken.
         new Log();
 
-        String[] levels = { "/level/3.txt"};
+        String[] levels = {"/level/1.txt", "/level/2.txt", "/level/3.txt"};
         new Launcher().start(levels);
     }
 

--- a/src/main/java/website/frontrow/Launcher.java
+++ b/src/main/java/website/frontrow/Launcher.java
@@ -49,7 +49,7 @@ public class Launcher implements Logable
         // Initialize the Logger Class, so that it can Log actions taken.
         new Log();
 
-        String[] levels = {"/level/1.txt", "/level/2.txt", "/level/3.txt"};
+        String[] levels = { "/level/3.txt"};
         new Launcher().start(levels);
     }
 

--- a/src/main/java/website/frontrow/board/Mover.java
+++ b/src/main/java/website/frontrow/board/Mover.java
@@ -96,8 +96,6 @@ public abstract class Mover
      */
     public void goLeft()
     {
-        // The horizontal orientation must immediately be changed, so the current horizontal motion
-        // is set to 0.
         this.newMotion.setX(-GameConstants.MOVE_STEP);
     }
 
@@ -161,15 +159,14 @@ public abstract class Mover
 
         Point movement = motion.divide(GameConstants.TICKS_PER_SEC);
 
-        if (!movement.toString().equals("Point(0.0, 0.0)"))
-        {
-            addToLog("[MOVER]\tMoved to " + movement.toString());
-        }
-
         this.handler = new CollisionHandler(level);
         this.handler.checkUnitsAABB(this);
         this.location = handler.findNextPosition(this).getPoint();
 
+        if (!movement.equals(new Point(0, 0)))
+        {
+            addToLog("[MOVER]\tMoved to " + this.location.toString());
+        }
         applyGravity();
     }
 

--- a/src/main/java/website/frontrow/level/Level.java
+++ b/src/main/java/website/frontrow/level/Level.java
@@ -69,11 +69,14 @@ public class Level
      */
     public ArrayList<Unit> getUnits()
     {
-        return new ArrayList<>(units);
+        ArrayList<Unit> toReturn = new ArrayList<>(units);
+        return toReturn;
     }
 
     /**
      * Add a unit to the queue.
+     * Be warned, the units do not appear in the method getUnits()
+     * until the method tick has been called.
      * @param unit Unit to add to the level.
      */
     public void addUnit(Unit unit)

--- a/src/main/java/website/frontrow/level/Level.java
+++ b/src/main/java/website/frontrow/level/Level.java
@@ -69,8 +69,7 @@ public class Level
      */
     public ArrayList<Unit> getUnits()
     {
-        ArrayList<Unit> toReturn = new ArrayList<>(units);
-        return toReturn;
+        return new ArrayList<>(units);
     }
 
     /**

--- a/src/main/java/website/frontrow/level/Level.java
+++ b/src/main/java/website/frontrow/level/Level.java
@@ -20,7 +20,7 @@ public class Level
     implements Logable
 {
 
-    private ConcurrentLinkedQueue<Unit> toAdd = new ConcurrentLinkedQueue<>();
+    private ConcurrentLinkedQueue<Unit> unitsToAdd = new ConcurrentLinkedQueue<>();
 
     private ArrayList<Player> players;
     private ArrayList<Unit> units;
@@ -78,7 +78,7 @@ public class Level
      */
     public void addUnit(Unit unit)
     {
-        toAdd.add(unit);
+        unitsToAdd.add(unit);
     }
 
     /**
@@ -97,9 +97,9 @@ public class Level
      */
     public void tick()
     {
-        while(!toAdd.isEmpty())
+        while(!unitsToAdd.isEmpty())
         {
-            units.add(toAdd.poll());
+            units.add(unitsToAdd.poll());
         }
         Unit unit;
         Iterator<Unit> it = units.iterator();
@@ -143,8 +143,6 @@ public class Level
                 cellToDraw.draw(g,
                         x + i * cellWidth, y + v * cellHeight,
                         cellWidth, cellHeight);
-                
-                
             }
         }
         
@@ -230,7 +228,6 @@ public class Level
      */
     public void updateObservers()
     {
-
         if (!playersAlive())
         {
             for(LevelObserver o : observers)
@@ -245,7 +242,6 @@ public class Level
                 o.levelWon();
             }
         }
-
     }
 
     /**

--- a/src/main/java/website/frontrow/level/MapParser.java
+++ b/src/main/java/website/frontrow/level/MapParser.java
@@ -48,7 +48,8 @@ public class MapParser
         {
             if (line.length() != len)
             {
-                addToLog("[ERROR]\t[MAP PARSER]\t3 - One of the lines in the file is not as long as the other.");
+                addToLog("[ERROR]\t[MAP PARSER]\t3 - One of the lines in the file "
+                        + "is not as long as the other.");
                 return false;
             }
         }

--- a/src/main/java/website/frontrow/util/CollisionHandler.java
+++ b/src/main/java/website/frontrow/util/CollisionHandler.java
@@ -246,9 +246,50 @@ public class CollisionHandler
 			mover.onWallCollision();
 		}
 
-		return new Collision(new Point(
-					Math.round(collision.getPoint().getX() * ONE_DEV_PRECISION) * PRECISION,
-					Math.round(collision.getPoint().getY() * ONE_DEV_PRECISION) * PRECISION
-			), collision.isCollided());
+        double newXLocation
+                = Math.round(collision.getPoint().getX() * ONE_DEV_PRECISION) * PRECISION;
+        double newYLocation
+                = Math.round(collision.getPoint().getY() * ONE_DEV_PRECISION) * PRECISION;
+
+        Point newLocation = new Point(newXLocation, newYLocation);
+
+        newLocation = checkLevelBounds(mover, newLocation);
+		return new Collision(newLocation, collision.isCollided());
+	}
+
+	/**
+	 * Checks whether the the mover is outside the bounds
+	 * of the level and gives the correct new location.
+     *
+     * When the player goes through the bottom it appears at the top of the level.
+     * When the player goes through the top of the level it appears at the bottom of the level.
+     *
+     * If the player tries to go through the sides of the level, nothing happens.
+	 * @param mover the mover to check the level bounds for.
+	 * @param newLocation the new location to check.
+	 * @return The new location based on the bounds of the level.
+	 */
+	public Point checkLevelBounds(Mover mover, Point newLocation)
+	{
+        AABB boundingBox = mover.getAABB();
+        double lowerLimit = this.level.getCells().getHeight() - boundingBox.getYRange().length();
+        double upperLimit = 0;
+
+        double leftLimit = 0;
+        double rightLimit = this.level.getCells().getWidth() - boundingBox.getXRange().length();
+
+        double newXLocation = Math.min(Math.max(leftLimit, newLocation.getX()), rightLimit);
+        double newYLocation = newLocation.getY();
+
+        if(newYLocation > lowerLimit)
+        {
+            newYLocation = upperLimit;
+        }
+        if(newYLocation < upperLimit)
+        {
+            newYLocation = lowerLimit;
+        }
+
+		return new Point(newXLocation, newYLocation);
 	}
 }

--- a/src/main/java/website/frontrow/util/CollisionHandler.java
+++ b/src/main/java/website/frontrow/util/CollisionHandler.java
@@ -284,10 +284,12 @@ public class CollisionHandler
         if(newYLocation > lowerLimit)
         {
             newYLocation = upperLimit;
+			addToLog("[CH]\tA mover went through the bottom of the level.");
         }
         if(newYLocation < upperLimit)
         {
             newYLocation = lowerLimit;
+			addToLog("[CH]\tA mover went through the top of the level.");
         }
 
 		return new Point(newXLocation, newYLocation);

--- a/src/main/resources/level/3.txt
+++ b/src/main/resources/level/3.txt
@@ -1,6 +1,6 @@
 XX____  ___  ___XX
 XX              XX
-XX              XX
+XX   __         XX
 XX              XX
 XX   e      e   XX
 XX ____    ____ XX
@@ -10,9 +10,9 @@ XX _____  _____ XX
 XX _          _ XX
 XX _          _ XX
 XX _____  _____ XX
-XX              XX
-XX              XX
-XX___ __  __ ___XX
+                  
+                  
+_____ __  __ ___  
 XX              XX
 XX p            XX
 XX____  __  ____XX

--- a/src/test/java/website/frontrow/board/MoverTest.java
+++ b/src/test/java/website/frontrow/board/MoverTest.java
@@ -3,11 +3,17 @@ package website.frontrow.board;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
 import website.frontrow.level.Level;
 import website.frontrow.game.GameConstants;
+import website.frontrow.level.MapParser;
 import website.frontrow.util.Grid;
 import website.frontrow.util.Point;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 
 import static org.junit.Assert.assertTrue;
@@ -17,6 +23,7 @@ import static org.junit.Assert.assertEquals;
  * Tests the mover class.
  *
  */
+@RunWith(MockitoJUnitRunner.class)
 public abstract class MoverTest
     extends UnitTest
 {
@@ -148,50 +155,64 @@ public abstract class MoverTest
         u.tick(emptyLevel);
         // TODO When collisions are implemented, some calls to those checks need to be checked here.
 
-        assertEquals(0.25, u.getLocation().getX(), 0.0004);
+        assertEquals(-1, u.getLocation().getX(), 0.0004);
     }
 
     /**
      * Test whether the unit moves left.
+     * @throws IOException The test file might not be found.
      */
     @Test
-    public void testGoLeft()
+    public void testGoLeft() throws IOException
     {
-        Mover u = getTestMover(true, new Point(0, 0), new Point(0, 0));
+        MapParser mp = new MapParser();
+        InputStream map = getClass().getResourceAsStream("/testMove.txt");
+        Level level = mp.parseMap(map);
+
+        Player u = level.getPlayers().get(0);
+        Point location = u.getLocation();
 
         u.goLeft();
-        u.tick(emptyLevel);
-
-        assertTrue(u.getLocation().getX() < 0);
+        u.tick(level);
+        assertTrue(u.getLocation().getX() < location.getX());
     }
 
     /**
      * Test whether the unit moves right.
+     * @throws IOException The test file might not be found.
      */
     @Test
-    public void testGoRight()
+    public void testGoRight() throws IOException
     {
-        Mover u = getTestMover(true, new Point(0, 0), new Point(0, 0));
+        MapParser mp = new MapParser();
+        InputStream map = getClass().getResourceAsStream("/testMove.txt");
+        Level level = mp.parseMap(map);
+
+        Player u = level.getPlayers().get(0);
+        Point location = u.getLocation();
 
         u.goRight();
-        u.tick(emptyLevel);
-
-        assertTrue(u.getLocation().getX() > 0);
+        u.tick(level);
+        assertTrue(u.getLocation().getX() > location.getX());
     }
 
     /**
      * Tests whether the unit does not move when not speed is given.
      * Except there is gravity. So we need to keep that in mind.
+     * @throws IOException The test file might not be found.
      */
     @Test
-    public void testDontMove() // There's a wasp in your hair.
+    public void testDontMove() throws IOException
     {
-        Point start = new Point(0, 0);
-        Mover u = getTestMover(true, start, new Point(0, 0));
+        MapParser mp = new MapParser();
+        InputStream map = getClass().getResourceAsStream("/testMove.txt");
+        Level level = mp.parseMap(map);
 
-        u.tick(emptyLevel);
+        Player u = level.getPlayers().get(0);
+        Point location = u.getLocation();
 
-        assertEquals(0, u.getLocation().getX(), 0.00001);
+        u.tick(level);
+        assertEquals(u.getLocation().getX(), location.getX(), 0.001);
     }
 
     /**

--- a/src/test/java/website/frontrow/level/LevelTest.java
+++ b/src/test/java/website/frontrow/level/LevelTest.java
@@ -13,7 +13,11 @@ import website.frontrow.util.Grid;
 
 import java.util.ArrayList;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -76,5 +80,22 @@ public class LevelTest
         level.tick();
         verify(player, times(1)).tick(level);
         verify(enemy, times(2)).tick(level);
+    }
+
+    /**
+     * Tests the add method.
+     */
+    @Test
+    public void testAddUnit()
+    {
+        Level level = new Level(null, mockunits, grid);
+        Unit mockedUnit = mock(Unit.class);
+        when(mockedUnit.isAlive()).thenReturn(true);
+        level.addUnit(mockedUnit);
+
+        assertFalse(level.getUnits().contains(mockedUnit));
+
+        level.tick();
+        assertTrue(level.getUnits().contains(mockedUnit));
     }
 }

--- a/src/test/java/website/frontrow/util/CollisionHandlerTest.java
+++ b/src/test/java/website/frontrow/util/CollisionHandlerTest.java
@@ -156,7 +156,7 @@ public class CollisionHandlerTest
      * Test getNextPosition in a terrible box of terribleness.
      */
     @Test
-    public void getNextPositionTestRestricted()
+    public void testGetNextPositionTestRestricted()
     {
         Level check = new Level(emptyPlayer, emptyUnit, new Grid<>(Arrays.asList(
                 Cell.WALL, Cell.WALL, Cell.WALL,
@@ -174,7 +174,7 @@ public class CollisionHandlerTest
      * Some special box of terribleness.
      */
     @Test
-    public void getNextPositionTestSlightlyRestricted()
+    public void testGetNextPositionTestSlightlyRestricted()
     {
         Level check = new Level(emptyPlayer, emptyUnit, new Grid<>(Arrays.asList(
                 Cell.WALL, Cell.WALL, Cell.WALL,

--- a/src/test/java/website/frontrow/util/CollisionHandlerTest.java
+++ b/src/test/java/website/frontrow/util/CollisionHandlerTest.java
@@ -4,9 +4,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import website.frontrow.board.Bubble;
-import website.frontrow.board.Enemy;
+import website.frontrow.board.Mover;
 import website.frontrow.board.Player;
+import website.frontrow.board.Enemy;
+import website.frontrow.board.Bubble;
 import website.frontrow.board.Unit;
 import website.frontrow.game.GameConstants;
 import website.frontrow.level.Cell;
@@ -18,6 +19,9 @@ import java.util.Arrays;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -152,7 +156,7 @@ public class CollisionHandlerTest
      * Test getNextPosition in a terrible box of terribleness.
      */
     @Test
-    public void getNextPositionTestRetricted()
+    public void getNextPositionTestRestricted()
     {
         Level check = new Level(emptyPlayer, emptyUnit, new Grid<>(Arrays.asList(
                 Cell.WALL, Cell.WALL, Cell.WALL,
@@ -170,7 +174,7 @@ public class CollisionHandlerTest
      * Some special box of terribleness.
      */
     @Test
-    public void getNextPositionTestSlightlyRetricted()
+    public void getNextPositionTestSlightlyRestricted()
     {
         Level check = new Level(emptyPlayer, emptyUnit, new Grid<>(Arrays.asList(
                 Cell.WALL, Cell.WALL, Cell.WALL,
@@ -183,5 +187,115 @@ public class CollisionHandlerTest
         Collision c = handler.findNextPosition(player);
         assertEquals(new Point(1, 2), c.getPoint());
         assertTrue(c.isCollided());
+    }
+
+    /**
+     * Test the level bounds when the mover is not near it.
+     */
+    @Test
+    public void testCheckLevelBoundsWithinBounds()
+    {
+        Mover mover = mock(Mover.class, RETURNS_DEEP_STUBS);
+        when(mover.getAABB().getXRange().length()).thenReturn(1.0);
+        when(mover.getAABB().getYRange().length()).thenReturn(1.0);
+
+        Level level = mock(Level.class, RETURNS_DEEP_STUBS);
+        when(level.getCells().getWidth()).thenReturn(10);
+        when(level.getCells().getHeight()).thenReturn(10);
+
+        CollisionHandler ch = new CollisionHandler(level);
+
+        Point targetLocation = new Point(5, 2);
+        Point finalLocation = ch.checkLevelBounds(mover, targetLocation);
+
+        assertEquals(targetLocation, finalLocation);
+    }
+
+    /**
+     * Test the level bounds when the mover is about to go over the x bounds.
+     */
+    @Test
+    public void testCheckLevelBoundsNearRightBounds()
+    {
+        Mover mover = mock(Mover.class, RETURNS_DEEP_STUBS);
+        when(mover.getAABB().getXRange().length()).thenReturn(1.0);
+        when(mover.getAABB().getYRange().length()).thenReturn(1.0);
+
+        Level level = mock(Level.class, RETURNS_DEEP_STUBS);
+        when(level.getCells().getWidth()).thenReturn(10);
+        when(level.getCells().getHeight()).thenReturn(10);
+
+        CollisionHandler ch = new CollisionHandler(level);
+
+        Point targetLocation = new Point(10, 1);
+        Point finalLocation = ch.checkLevelBounds(mover, targetLocation);
+
+        assertTrue(targetLocation.getX() > finalLocation.getX());
+    }
+
+    /**
+     * Test the level bounds when the mover is about to go under the x bounds.
+     */
+    @Test
+    public void testCheckLevelBoundsNearLeftBounds()
+    {
+        Mover mover = mock(Mover.class, RETURNS_DEEP_STUBS);
+        when(mover.getAABB().getXRange().length()).thenReturn(1.0);
+        when(mover.getAABB().getYRange().length()).thenReturn(1.0);
+
+        Level level = mock(Level.class, RETURNS_DEEP_STUBS);
+        when(level.getCells().getWidth()).thenReturn(10);
+        when(level.getCells().getHeight()).thenReturn(10);
+
+        CollisionHandler ch = new CollisionHandler(level);
+
+        Point targetLocation = new Point(-1, 1);
+        Point finalLocation = ch.checkLevelBounds(mover, targetLocation);
+
+        assertTrue(targetLocation.getX() < finalLocation.getX());
+    }
+
+    /**
+     * Test the level bounds when the mover is about to go over the y bounds.
+     */
+    @Test
+    public void testCheckLevelBoundsOverLowerBounds()
+    {
+        Mover mover = mock(Mover.class, RETURNS_DEEP_STUBS);
+        when(mover.getAABB().getXRange().length()).thenReturn(1.0);
+        when(mover.getAABB().getYRange().length()).thenReturn(1.0);
+
+        Level level = mock(Level.class, RETURNS_DEEP_STUBS);
+        when(level.getCells().getWidth()).thenReturn(10);
+        when(level.getCells().getHeight()).thenReturn(10);
+
+        CollisionHandler ch = new CollisionHandler(level);
+
+        Point targetLocation = new Point(2, 11);
+        Point finalLocation = ch.checkLevelBounds(mover, targetLocation);
+
+        assertTrue(targetLocation.getY() > finalLocation.getY());
+    }
+
+    /**
+     * Test the level bounds when the mover is about to go under the y bounds.
+     */
+    @Test
+    public void testCheckLevelBoundsOverUpperBounds()
+    {
+        Mover mover = mock(Mover.class, RETURNS_DEEP_STUBS);
+        when(mover.getAABB().getXRange().length()).thenReturn(1.0);
+        when(mover.getAABB().getYRange().length()).thenReturn(1.0);
+
+        Level level = mock(Level.class, RETURNS_DEEP_STUBS);
+        when(level.getCells().getWidth()).thenReturn(10);
+        when(level.getCells().getHeight()).thenReturn(10);
+
+        CollisionHandler ch = new CollisionHandler(level);
+
+        Point targetLocation = new Point(2, -1);
+        Point finalLocation = ch.checkLevelBounds(mover, targetLocation);
+
+        assertTrue(targetLocation.getY() < finalLocation.getY());
     }
 }

--- a/src/test/resources/testMove.txt
+++ b/src/test/resources/testMove.txt
@@ -1,0 +1,5 @@
+XXXXXXX
+X     X
+X     X
+X p   X
+XXXXXXX


### PR DESCRIPTION
The player can't go through the sides of the level, it can however go through the bottom and top. When the player goes through the bottom, it appears at the top. When the payer goes through the top of the level it appears at the bottom.

<feature, naming, testing